### PR TITLE
Re-add distance.uiowa.edu to uiowa703

### DIFF
--- a/.sites.yml
+++ b/.sites.yml
@@ -1849,6 +1849,10 @@ sites:
             type: custom
             git: 'git@github.com:ITS-UofIowa/discover.research.uiowa.edu.git'
             profile: sitenow
+        distance.uiowa.edu:
+            type: custom
+            git: 'git@github.com:ITS-UofIowa/distance.uiowa.edu.git'
+            profile: sitenow
         diversity.uiowa.edu:
             type: custom
             git: 'git@github.com:ITS-UofIowa/diversity.uiowa.edu.git'


### PR DESCRIPTION
Now that the sites are grouped by application, we should be able to develop a custom site for distance.uiowa.edu on 703 and continue to use the current standard site on 701 until the new website is ready to go live.