### PR TITLE
Add standard sites

### DIFF
--- a/.sites.yml
+++ b/.sites.yml
@@ -1657,6 +1657,10 @@ sites:
             type: standard
             profile: sitenow_standard_profile
             git: null
+        turek.lab.uiowa.edu:
+            type: standard
+            profile: sitenow_standard_profile
+            git: null
         turkish.org.uiowa.edu:
             type: standard
             profile: sitenow_standard_profile

--- a/.sites.yml
+++ b/.sites.yml
@@ -1269,6 +1269,10 @@ sites:
             type: standard
             profile: sitenow_standard_profile
             git: null
+        london.lab.uiowa.edu:
+            type: standard
+            profile: sitenow_standard_profile
+            git: null
         lynda.uiowa.edu:
             type: custom
             git: 'git@github.com:ITS-UofIowa/lynda.uiowa.edu.git'

--- a/.sites.yml
+++ b/.sites.yml
@@ -349,6 +349,10 @@ sites:
             git: null
             redirects:
                 - www.uiowa.edu/icru
+        uiowa.edu/igem:
+            type: standard
+            profile: sitenow_standard_profile
+            git: null
         uiowa.edu/ijcs:
             type: standard
             profile: sitenow_standard_profile


### PR DESCRIPTION
Added:

- uiowa.edu/igem
- london.lab.uiowa.edu
- turek.lab.uiowa.edu