### PR TITLE
added hackiowa.org.uiowa.edu

### DIFF
--- a/.sites.yml
+++ b/.sites.yml
@@ -1364,6 +1364,10 @@ sites:
             git: null
             drush-groups:
                 - uihc_labs
+        hackiowa.org.uiowa.edu:
+            type: standard
+            profile: sitenow_standard_profile
+            git: null
         habelhah.lab.uiowa.edu:
             type: standard
             profile: sitenow_standard_profile


### PR DESCRIPTION
added:
hackiowa.org.uiowa.edu:
    type: standard
    profile: sitenow_standard_profile
    git: null