### PR TITLE
remove colleencampbell.lab.uiowa.edu

### DIFF
--- a/.sites.yml
+++ b/.sites.yml
@@ -1170,12 +1170,6 @@ sites:
             git: null
             drush-groups:
                 - uihc_labs
-        colleencampbell.lab.uiowa.edu:
-            type: standard
-            profile: sitenow_standard_profile
-            git: null
-            drush-groups:
-                - uihc_labs
         cpl.lab.uiowa.edu:
             type: standard
             profile: sitenow_standard_profile


### PR DESCRIPTION
since https://colleen-campbell.lab.uiowa.edu was used instead