### PR TITLE
idcard updates

### DIFF
--- a/.sites.yml
+++ b/.sites.yml
@@ -2503,6 +2503,8 @@ sites:
             type: standard
             profile: sitenow_standard_profile
             git: null
+            redirects:
+                - idcard.fo.uiowa.edu
         iexplorestem.org:
             type: custom
             profile: sitenow
@@ -2926,12 +2928,6 @@ sites:
             type: custom
             profile: sitenow
             git: 'git@github.com:ITS-UofIowa/icater.education.uiowa.edu.git'
-        idcard.fo.uiowa.edu:
-            type: custom
-            git: 'git@github.com:ITS-UofIowa/idcard.fo.uiowa.edu.git'
-            profile: sitenow
-            drush-groups:
-                - fo_suite
         iisc.uiowa.edu:
             type: custom
             git: 'git@github.com:ITS-UofIowa/iisc.uiowa.edu.git'


### PR DESCRIPTION
Removed idcard.fo.uiowa.edu from 703.
Add idcard.fo.uiowa.edu as a redirect to idcard.uiowa.edu on 702.