### PR TITLE
Add uefauiowa.org.uiowa.edu to drupal manifest.

### DIFF
--- a/.sites.yml
+++ b/.sites.yml
@@ -2451,6 +2451,10 @@ sites:
             type: standard
             profile: sitenow_standard_profile
             git: null
+        uefauiowa.org.uiowa.edu:
+            type: standard
+            profile: sitenow_standard_profile
+            git: null
         uibestbuddies.org.uiowa.edu:
             type: standard
             profile: sitenow_standard_profile


### PR DESCRIPTION
Under uiowa701.