### PR TITLE
redirect www.oldcapitoltennis

### DIFF
--- a/.sites.yml
+++ b/.sites.yml
@@ -3074,8 +3074,7 @@ sites:
             profile: sitenow_standard_profile
             git: null
             redirects:
-                - www.oldcapitolfutures.com
-                - oldcapitolfutures.com
+                - www.oldcapitoltennis.com
         pappajohnentrepreneurialventurecompetition.com:
             type: custom
             profile: sitenow


### PR DESCRIPTION
Also removed redirects for oldcapitolfutures.com since using domain forwarding now.