### PR TITLE
Replace domain

### DIFF
--- a/.sites.yml
+++ b/.sites.yml
@@ -769,10 +769,6 @@ sites:
             git: null
             drush-groups:
                 - uihc_labs
-        alphachapterslg.org.uiowa.edu:
-            type: standard
-            profile: sitenow_standard_profile
-            git: null
         amendt.lab.uiowa.edu:
             type: standard
             profile: sitenow_standard_profile
@@ -2470,6 +2466,10 @@ sites:
             profile: sitenow_standard_profile
             git: null
         uiowaclubglax.org.uiowa.edu:
+            type: standard
+            profile: sitenow_standard_profile
+            git: null
+        uiowagammas.org.uiowa.edu:
             type: standard
             profile: sitenow_standard_profile
             git: null


### PR DESCRIPTION
- Removed alphachapterslg.org.uiowa.edu
- Added uiowagammas.org.uiowa.edu